### PR TITLE
Create "add" task command and invalid command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+data.json
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # task-tracker
+
 CLI app to track your tasks and manage your to-do list
+
+https://roadmap.sh/projects/task-tracker
+
+Build a simple command line interface (CLI) to track what you need to do, what you have done, and what you are currently working on.
+Practice working with the filesystem, handling user inputs, and building a simple CLI application
+
+# Requirements
+
+The application should run from the command line, accept user actions and inputs as arguments, and store the tasks in a JSON file. The user should be able to:
+
+- Add, Update, and Delete tasks
+- Mark a task as in progress or done
+- List all tasks
+- List all tasks that are done
+- List all tasks that are not done
+- List all tasks that are in progress
+
+Here are some constraints to guide the implementation:
+
+- You can use any programming language to build this project.
+- Use positional arguments in command line to accept user inputs.
+- Use a JSON file to store the tasks in the current directory.
+- The JSON file should be created if it does not exist.
+- Use the native file system module of your programming language to interact with the JSON file.
+- Do not use any external libraries or frameworks to build this project.
+- Ensure to handle errors and edge cases gracefully.
+
+## Example
+
+The list of commands and their usage is given below:
+
+```bash
+# Adding a new task
+task-cli add "Buy groceries"
+# Output: Task added successfully (ID: 1)
+
+# Updating and deleting tasks
+task-cli update 1 "Buy groceries and cook dinner"
+task-cli delete 1
+
+# Marking a task as in progress or done
+task-cli mark-in-progress 1
+task-cli mark-done 1
+
+# Listing all tasks
+task-cli list
+
+# Listing tasks by status
+task-cli list done
+task-cli list todo
+task-cli list in-progress
+```
+
+## Task Properties
+
+Each task should have the following properties:
+
+- `id`: A unique identifier for the task
+- `description`: A short description of the task
+- `status`: The status of the task (todo, in-progress, done)
+- `createdAt`: The date and time when the task was created
+- `updatedAt`: The date and time when the task was last updated
+
+Make sure to add these properties to the JSON file when adding a new task and update them when updating a task.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,34 @@ https://roadmap.sh/projects/task-tracker
 Build a simple command line interface (CLI) to track what you need to do, what you have done, and what you are currently working on.
 Practice working with the filesystem, handling user inputs, and building a simple CLI application
 
+# Running the application
+
+Execute the following command
+
+```bash
+node index.js
+```
+
+The save file will be created at the root directory of the project, as file `data.json`
+
+# Running tests
+
+The tests are written with node native test runner, with `mock-stdin` npm package for helping to pass stdin inputs to test cases
+
+Install the required package (`mock-stdin`) and run the tests
+
+```bash
+npm install
+npm run test
+```
+
+The save file will be deleted before and after a test case run
+
 # References
 
 1. node.js native test runner https://nodejs.org/api/test.html
 2. mock-stdin (for testing cli application) - https://www.npmjs.com/package/mock-stdin
+3. node.js equivalent of python's if `__name__` == `'__main__'` https://stackoverflow.com/questions/4981891/node-js-equivalent-of-pythons-if-name-main
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ https://roadmap.sh/projects/task-tracker
 Build a simple command line interface (CLI) to track what you need to do, what you have done, and what you are currently working on.
 Practice working with the filesystem, handling user inputs, and building a simple CLI application
 
+# References
+
+1. node.js native test runner https://nodejs.org/api/test.html
+2. mock-stdin (for testing cli application) - https://www.npmjs.com/package/mock-stdin
+
 # Requirements
 
 The application should run from the command line, accept user actions and inputs as arguments, and store the tasks in a JSON file. The user should be able to:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The save file will be created at the root directory of the project, as file `dat
 
 # Running tests
 
-The tests are written with node native test runner, with `mock-stdin` npm package for helping to pass stdin inputs to test cases
+The tests are written with node native test runner, with `mock-stdin` and `stdout-stderr` npm package for helping to pass stdin inputs to test cases and check stdout
 
-Install the required package (`mock-stdin`) and run the tests
+Install the required package (`mock-stdin`, `stdout-stderr`) and run the tests
 
 ```bash
 npm install
@@ -34,7 +34,8 @@ The save file will be deleted before and after a test case run
 
 1. node.js native test runner https://nodejs.org/api/test.html
 2. mock-stdin (for testing cli application) - https://www.npmjs.com/package/mock-stdin
-3. node.js equivalent of python's if `__name__` == `'__main__'` https://stackoverflow.com/questions/4981891/node-js-equivalent-of-pythons-if-name-main
+3. stdout-stderr (for testing cli application) - https://www.npmjs.com/package/stdout-stderr
+4. node.js equivalent of python's if `__name__` == `'__main__'` https://stackoverflow.com/questions/4981891/node-js-equivalent-of-pythons-if-name-main
 
 # Requirements
 

--- a/commands/addCommand.js
+++ b/commands/addCommand.js
@@ -1,0 +1,20 @@
+const { getSaveFileContent, writeToSaveFile } = require("../storage/file")
+
+class AddCommand {
+  constructor(task) {
+    this.task = task
+  }
+
+  execute() {
+    const existingContent = getSaveFileContent()
+    if (existingContent == null || existingContent === "") {
+      writeToSaveFile("[" + this.task.toString() + "]")
+    } else {
+      const tasks = JSON.parse(existingContent)
+      tasks.push(this.task.toJson())
+      writeToSaveFile(JSON.stringify(tasks))
+    }
+  }
+}
+
+module.exports = { AddCommand }

--- a/commands/addCommand.js
+++ b/commands/addCommand.js
@@ -5,6 +5,24 @@ class AddCommand {
     this.task = task
   }
 
+  static parseInput(input) {
+    // only text in double quotes are added
+    const hasTwoDoubleQuote =
+      input.split("").filter((x) => x === '"').length === 2
+    if (!hasTwoDoubleQuote) {
+      return { isValid: false }
+    }
+    const found = input.match(/"(?<description>.+)"/)
+    if (
+      found == null ||
+      found.groups == null ||
+      found.groups.description.trim().length === 0
+    ) {
+      return { isValid: false }
+    }
+    return { isValid: true, description: found.groups.description.trim() }
+  }
+
   execute() {
     const existingContent = getSaveFileContent()
     if (existingContent == null || existingContent === "") {

--- a/commands/addCommand.js
+++ b/commands/addCommand.js
@@ -14,6 +14,7 @@ class AddCommand {
       tasks.push(this.task.toJson())
       writeToSaveFile(JSON.stringify(tasks))
     }
+    return `Task added successfully (ID: ${this.task.id})`
   }
 }
 

--- a/commands/invalidCommand.js
+++ b/commands/invalidCommand.js
@@ -1,0 +1,20 @@
+class InvalidCommand {
+  constructor(input) {
+    this.input = input
+  }
+
+  execute() {
+    return `Invalid Command [${this.input}] given.
+    List of valid commands:
+    add [TASK_DESCRIPTION]
+    update [TASK_ID] [NEW_TASK_DESCRIPTION]
+    mark-in-progress [TASK_ID]
+    mark-done [TASK_ID]
+    list
+    list done
+    list todo
+    list in-progress`
+  }
+}
+
+module.exports = { InvalidCommand }

--- a/commands/invalidCommand.js
+++ b/commands/invalidCommand.js
@@ -6,8 +6,8 @@ class InvalidCommand {
   execute() {
     return `Invalid Command [${this.input}] given.
     List of valid commands:
-    add [TASK_DESCRIPTION]
-    update [TASK_ID] [NEW_TASK_DESCRIPTION]
+    add "[TASK_DESCRIPTION]"
+    update [TASK_ID] "[NEW_TASK_DESCRIPTION]"
     mark-in-progress [TASK_ID]
     mark-done [TASK_ID]
     list

--- a/index.js
+++ b/index.js
@@ -3,6 +3,29 @@ const { AddCommand } = require("./commands/addCommand")
 const { createSaveFile } = require("./storage/file")
 const { Task } = require("./model/task")
 
+function main() {
+  printProgramName()
+  createSaveFile()
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+  })
+  rl.on("line", (line) => {
+    const command = processLine(line)
+    if (command) {
+      const output = command.execute()
+      console.log(output)
+    }
+    printProgramName()
+  })
+}
+
+function printProgramName() {
+  process.stdout.write("task-cli ")
+}
+
 function processLine(line) {
   // returns a command to execute
   const commandKeyword = line.trim().split(/\s+/)[0]
@@ -15,20 +38,9 @@ function processLine(line) {
   }
 }
 
-function main() {
-  createSaveFile()
-
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-    terminal: true,
-  })
-  rl.on("line", (line) => {
-    const command = processLine(line)
-    if (command) {
-      command.execute()
-    }
-  })
+if (require.main === module) {
+  // when a file is run directly from Node, require.main is set to its module
+  main()
 }
 
 module.exports = { main }

--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ function printProgramName() {
 function processLine(line) {
   // returns a command to execute
   const commandKeyword = line.trim().split(/\s+/)[0]
-  const data = line.trim().slice(commandKeyword.length)
   switch (commandKeyword.toLowerCase()) {
     case "add":
-      return new AddCommand(new Task(data))
+      const { isValid, description } = AddCommand.parseInput(line)
+      return isValid
+        ? new AddCommand(new Task(description))
+        : new InvalidCommand(line)
     default:
       return new InvalidCommand(line)
   }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
 const readline = require("node:readline")
-const { AddCommand } = require("./commands/addCommand")
 const { createSaveFile } = require("./storage/file")
 const { Task } = require("./model/task")
+const { InvalidCommand } = require("./commands/invalidCommand")
+const { AddCommand } = require("./commands/addCommand")
 
-function main() {
+function main(input = process.stdin, output = process.stdout) {
   printProgramName()
   createSaveFile()
 
   const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
+    input,
+    output,
     terminal: true,
   })
   rl.on("line", (line) => {
@@ -34,7 +35,7 @@ function processLine(line) {
     case "add":
       return new AddCommand(new Task(data))
     default:
-      break
+      return new InvalidCommand(line)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,34 @@
+const readline = require("node:readline")
+const { AddCommand } = require("./commands/addCommand")
+const { createSaveFile } = require("./storage/file")
+const { Task } = require("./model/task")
+
+function processLine(line) {
+  // returns a command to execute
+  const commandKeyword = line.trim().split(/\s+/)[0]
+  const data = line.trim().slice(commandKeyword.length)
+  switch (commandKeyword.toLowerCase()) {
+    case "add":
+      return new AddCommand(new Task(data))
+    default:
+      break
+  }
+}
+
+function main() {
+  createSaveFile()
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+  })
+  rl.on("line", (line) => {
+    const command = processLine(line)
+    if (command) {
+      command.execute()
+    }
+  })
+}
+
+module.exports = { main }

--- a/model/task.js
+++ b/model/task.js
@@ -1,0 +1,40 @@
+const { getTotalTaskCount } = require("../storage/file")
+
+const TaskStatus = Object.freeze({
+  TODO: Symbol("todo"),
+  IN_PROGRESS: Symbol("in_progress"),
+  DONE: Symbol("done"),
+})
+
+class Task {
+  constructor(
+    description,
+    status = TaskStatus.TODO,
+    createdAt = new Date().toString(),
+    updatedAt = null
+  ) {
+    // generate id by getting save file task count and increment (what about int overflow?)
+    const count = Number.parseInt(getTotalTaskCount())
+    this.id = `${count + 1}`
+    this.description = description
+    this.status = status
+    this.createdAt = createdAt
+    this.updatedAt = updatedAt
+  }
+
+  toString() {
+    return JSON.stringify(this.toJson())
+  }
+
+  toJson() {
+    return {
+      id: this.id,
+      description: this.description,
+      status: this.status,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    }
+  }
+}
+
+module.exports = { Task, TaskStatus }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "task-tracker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "task-tracker",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "mock-stdin": "1.0.0"
+      }
+    },
+    "node_modules/mock-stdin": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
+      "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,34 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "mock-stdin": "1.0.0"
+        "mock-stdin": "1.0.0",
+        "stdout-stderr": "0.1.13"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/mock-stdin": {
@@ -17,6 +44,37 @@
       "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
       "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
       "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/stdout-stderr": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/stdout-stderr/-/stdout-stderr-0.1.13.tgz",
+      "integrity": "sha512-Xnt9/HHHYfjZ7NeQLvuQDyL1LnbsbddgMFKCuaQKwGCdJm8LnstZIXop+uOY36UR1UXXoHXfMbC1KlVdVd2JLA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/JeremyLoh/task-tracker#readme",
   "devDependencies": {
-    "mock-stdin": "1.0.0"
+    "mock-stdin": "1.0.0",
+    "stdout-stderr": "0.1.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "task-tracker",
+  "version": "1.0.0",
+  "description": "CLI app to track your tasks and manage your to-do list",
+  "main": "index.js",
+  "scripts": {
+    "cli": "node index.js",
+    "test": "node --test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JeremyLoh/task-tracker.git"
+  },
+  "author": "JeremyLoh",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/JeremyLoh/task-tracker/issues"
+  },
+  "homepage": "https://github.com/JeremyLoh/task-tracker#readme",
+  "devDependencies": {
+    "mock-stdin": "1.0.0"
+  }
+}

--- a/storage/file.js
+++ b/storage/file.js
@@ -1,0 +1,44 @@
+const fs = require("fs")
+const path = require("path")
+
+const SAVE_FILE_PATH = path.join(__dirname, "data.json")
+
+function getSaveFileContent() {
+  try {
+    return fs.readFileSync(SAVE_FILE_PATH, "utf8")
+  } catch (error) {
+    return null
+  }
+}
+
+function getTotalTaskCount() {
+  try {
+    const data = getSaveFileContent(SAVE_FILE_PATH)
+    if (data == null) {
+      return 0
+    }
+    const tasks = JSON.parse(data)
+    return tasks.length
+  } catch (error) {
+    console.error(
+      "getTotalTaskCount: Could not read save file / parse data in save file"
+    )
+    return 0
+  }
+}
+
+function createSaveFile() {
+  fs.writeFileSync(SAVE_FILE_PATH, "")
+}
+
+function writeToSaveFile(data) {
+  fs.writeFileSync(SAVE_FILE_PATH, data)
+}
+
+module.exports = {
+  SAVE_FILE_PATH,
+  getSaveFileContent,
+  getTotalTaskCount,
+  createSaveFile,
+  writeToSaveFile,
+}

--- a/storage/file.js
+++ b/storage/file.js
@@ -20,15 +20,14 @@ function getTotalTaskCount() {
     const tasks = JSON.parse(data)
     return tasks.length
   } catch (error) {
-    console.error(
-      "getTotalTaskCount: Could not read save file / parse data in save file"
-    )
     return 0
   }
 }
 
 function createSaveFile() {
-  fs.writeFileSync(SAVE_FILE_PATH, "")
+  if (!fs.existsSync(SAVE_FILE_PATH)) {
+    fs.writeFileSync(SAVE_FILE_PATH, "")
+  }
 }
 
 function writeToSaveFile(data) {

--- a/tests/addTask.test.js
+++ b/tests/addTask.test.js
@@ -4,8 +4,6 @@ const fs = require("node:fs")
 const { main } = require("../index.js")
 const { SAVE_FILE_PATH } = require("../storage/file.js")
 
-const stdin = require("mock-stdin").stdin()
-
 describe("add cli task", () => {
   beforeEach(() => {
     deleteSaveFile()
@@ -34,6 +32,7 @@ describe("add cli task", () => {
   }
 
   it("should add one task to JSON save file", () => {
+    const stdin = require("mock-stdin").stdin()
     main()
     stdin.send('add "Buy groceries"')
     assertSaveFileExists()
@@ -61,6 +60,27 @@ describe("add cli task", () => {
       saveFileData,
       /Buy groceries/,
       "Save file should have description of task"
+    )
+  })
+
+  it("should display invalid command message to user when invalid command is given", () => {
+    const invalidCommand = 'invalid command "Buy groceries"'
+    const stdin = require("mock-stdin").stdin()
+    const { stdout } = require("stdout-stderr")
+    stdout.start()
+    main()
+    stdin.send(invalidCommand)
+    stdin.end()
+    stdout.stop()
+    assert.match(
+      stdout.output,
+      new RegExp(String.raw`Invalid Command \[${invalidCommand}\] given.`),
+      "Invalid Command message should be displayed to user"
+    )
+    assert.match(
+      stdout.output,
+      /List of valid commands:/,
+      "Invalid Command message list of commands should be displayed to user"
     )
   })
 })

--- a/tests/addTask.test.js
+++ b/tests/addTask.test.js
@@ -1,0 +1,66 @@
+const { describe, it, beforeEach, after } = require("node:test")
+const assert = require("node:assert")
+const fs = require("node:fs")
+const { main } = require("../index.js")
+const { SAVE_FILE_PATH } = require("../storage/file.js")
+
+const stdin = require("mock-stdin").stdin()
+
+describe("add cli task", () => {
+  beforeEach(() => {
+    deleteSaveFile()
+  })
+
+  after(() => {
+    deleteSaveFile()
+  })
+
+  function deleteSaveFile() {
+    if (fs.existsSync(SAVE_FILE_PATH)) {
+      fs.unlinkSync(SAVE_FILE_PATH)
+    }
+  }
+
+  function readSaveFileContent() {
+    return fs.readFileSync(SAVE_FILE_PATH, "utf8")
+  }
+
+  function assertSaveFileExists() {
+    assert.strictEqual(
+      fs.existsSync(SAVE_FILE_PATH),
+      true,
+      `Save File does not exist at ${SAVE_FILE_PATH}`
+    )
+  }
+
+  it("should add one task to JSON save file", () => {
+    main()
+    stdin.send('add "Buy groceries"')
+    assertSaveFileExists()
+    stdin.end()
+    assertSaveFileExists()
+
+    const saveFileData = readSaveFileContent()
+    const taskEntries = JSON.parse(saveFileData)
+    assert.strictEqual(
+      taskEntries.length,
+      1,
+      "Save file should have one new task"
+    )
+    assert.match(
+      saveFileData,
+      /"createdAt":/,
+      "Save file should have one new task with createdAt field"
+    )
+    assert.match(
+      saveFileData,
+      /"updatedAt":null/,
+      "Save file should have one new task with updatedAt field of null"
+    )
+    assert.match(
+      saveFileData,
+      /Buy groceries/,
+      "Save file should have description of task"
+    )
+  })
+})

--- a/tests/addTask.test.js
+++ b/tests/addTask.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert")
 const fs = require("node:fs")
 const { main } = require("../index.js")
 const { SAVE_FILE_PATH } = require("../storage/file.js")
+const { EOL } = require("node:os")
 
 describe("add cli task", () => {
   beforeEach(() => {
@@ -67,6 +68,39 @@ describe("add cli task", () => {
       saveFileData,
       /"id":"1","description":"Buy groceries"/,
       "Save file should have description of task"
+    )
+  })
+
+  it("should allow multiple tasks to be added", () => {
+    const { stdin } = mockStdinAndStdout()
+    main()
+    stdin.send(`add "FIRST'_'TASK"` + EOL)
+    stdin.send('add "second    task"' + EOL)
+    stdin.send(' add      "  third  =  task "   ' + EOL)
+    stdin.end()
+
+    assertSaveFileExists()
+    const saveFileData = readSaveFileContent()
+    const taskEntries = JSON.parse(saveFileData)
+    assert.strictEqual(
+      taskEntries.length,
+      3,
+      "Save file should have three new tasks"
+    )
+    assert.match(
+      saveFileData,
+      /"id":"1","description":"FIRST'_'TASK"/,
+      "Save file should have description of first task"
+    )
+    assert.match(
+      saveFileData,
+      /"id":"2","description":"second    task"/,
+      "Save file should have description of first task"
+    )
+    assert.match(
+      saveFileData,
+      /"id":"3","description":"third  =  task"/,
+      "Save file should have description of first task"
     )
   })
 


### PR DESCRIPTION
Uses Command Design Pattern to structure the commands - https://refactoring.guru/design-patterns/command

Only allows two double quotes for a command (e.g. `add "test" "` is invalid)
- Saves tasks as List of JSON strings (`JSON.stringify`) as `data.json` file in the root directory

Create invalid command (when user input for first word does not match a command)
- Prints a message on how to use the application

### Testing
Uses node.js native test runner https://nodejs.org/api/test.html
1. mock-stdin (for testing cli application) - https://www.npmjs.com/package/mock-stdin
2. stdout-stderr (for testing cli application) - https://www.npmjs.com/package/stdout-stderr
3. Each run of test case will create and delete the `data.json` file