### PR TITLE
Add mark-done and mark-in-progress command, Fix flaky test due to parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The save file will be created at the root directory of the project, as file `dat
 
 # Running tests
 
+## To prevent flaky tests due to writing to same save json file, ensure vitest is running with flag `vitest --sequence.concurrent=false --no-file-parallelism`
+
+https://vitest.dev/guide/improving-performance#test-isolation
+
 The tests are written with `vitest`, with `mock-stdin` and `stdout-stderr` npm package for helping to pass stdin inputs to test cases and check stdout
 
 Install the required package (`mock-stdin`, `stdout-stderr`) and run the tests

--- a/commands/markDoneCommand.js
+++ b/commands/markDoneCommand.js
@@ -1,0 +1,22 @@
+const { TaskStatus } = require("../model/task")
+const { writeToSaveFile } = require("../storage/file")
+
+class MarkDoneCommand {
+  constructor(tasks, index) {
+    this.tasks = tasks
+    this.index = index
+  }
+
+  execute() {
+    // index is zero based
+    if (this.index < 0 || this.tasks[this.index] == null) {
+      return `Invalid index provided [${this.index + 1}]`
+    }
+    this.tasks[this.index]["status"] = TaskStatus.DONE.description
+    this.tasks[this.index]["updatedAt"] = new Date().toString()
+    writeToSaveFile(JSON.stringify(this.tasks))
+    return `Marked Task ${this.index + 1} as done`
+  }
+}
+
+module.exports = { MarkDoneCommand }

--- a/commands/markInProgressCommand.js
+++ b/commands/markInProgressCommand.js
@@ -1,0 +1,22 @@
+const { TaskStatus } = require("../model/task")
+const { writeToSaveFile } = require("../storage/file")
+
+class MarkInProgressCommand {
+  constructor(tasks, index) {
+    this.tasks = tasks
+    this.index = index
+  }
+
+  execute() {
+    // index is zero based
+    if (this.index < 0 || this.tasks[this.index] == null) {
+      return `Invalid index provided [${this.index + 1}]`
+    }
+    this.tasks[this.index]["status"] = TaskStatus.IN_PROGRESS.description
+    this.tasks[this.index]["updatedAt"] = new Date().toString()
+    writeToSaveFile(JSON.stringify(this.tasks))
+    return `Marked Task ${this.index + 1} as in-progress`
+  }
+}
+
+module.exports = { MarkInProgressCommand }

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const { Task } = require("./model/task")
 const { InvalidCommand } = require("./commands/invalidCommand")
 const { AddCommand } = require("./commands/addCommand")
 const { ListCommand } = require("./commands/listCommand")
+const { MarkDoneCommand } = require("./commands/markDoneCommand")
 
 function main(onExit) {
   printProgramName()
@@ -48,6 +49,15 @@ function processLine(line) {
       return isValid
         ? new AddCommand(new Task(description))
         : new InvalidCommand(line)
+    case "mark-done":
+      try {
+        return new MarkDoneCommand(
+          getAllTasks(),
+          Number.parseInt(words[1].trim()) - 1
+        )
+      } catch (error) {
+        return new InvalidCommand(line)
+      }
     default:
       return new InvalidCommand(line)
   }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const { InvalidCommand } = require("./commands/invalidCommand")
 const { AddCommand } = require("./commands/addCommand")
 const { ListCommand } = require("./commands/listCommand")
 const { MarkDoneCommand } = require("./commands/markDoneCommand")
+const { MarkInProgressCommand } = require("./commands/markInProgressCommand")
 
 function main(onExit) {
   printProgramName()
@@ -52,6 +53,15 @@ function processLine(line) {
     case "mark-done":
       try {
         return new MarkDoneCommand(
+          getAllTasks(),
+          Number.parseInt(words[1].trim()) - 1
+        )
+      } catch (error) {
+        return new InvalidCommand(line)
+      }
+    case "mark-in-progress":
+      try {
+        return new MarkInProgressCommand(
           getAllTasks(),
           Number.parseInt(words[1].trim()) - 1
         )

--- a/model/task.js
+++ b/model/task.js
@@ -2,7 +2,7 @@ const { getTotalTaskCount } = require("../storage/file")
 
 const TaskStatus = Object.freeze({
   TODO: Symbol("todo"),
-  IN_PROGRESS: Symbol("in_progress"),
+  IN_PROGRESS: Symbol("in-progress"),
   DONE: Symbol("done"),
 })
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "cli": "node index.js",
-    "test": "vitest"
+    "test": "vitest --sequence.concurrent=false --no-file-parallelism"
   },
   "repository": {
     "type": "git",

--- a/tests/addCommand.test.js
+++ b/tests/addCommand.test.js
@@ -1,13 +1,9 @@
-import { describe, it, beforeEach, afterEach, expect } from "vitest"
-const fs = require("node:fs")
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest"
 const { EOL } = require("node:os")
+import { deleteSaveFile, readSaveFileContent } from "./testUtil.js"
 const { main } = require("../index.js")
-const { SAVE_FILE_PATH } = require("../storage/file.js")
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-const WAIT_TIME_FOR_IO_IN_MS = 500
-
-describe("add command", () => {
+describe("add command", async () => {
   beforeEach(() => {
     deleteSaveFile()
   })
@@ -15,16 +11,6 @@ describe("add command", () => {
   afterEach(() => {
     deleteSaveFile()
   })
-
-  function deleteSaveFile() {
-    if (fs.existsSync(SAVE_FILE_PATH)) {
-      fs.unlinkSync(SAVE_FILE_PATH)
-    }
-  }
-
-  function readSaveFileContent() {
-    return fs.readFileSync(SAVE_FILE_PATH, "utf8")
-  }
 
   function mockStdinAndStdout() {
     const stdin = require("mock-stdin").stdin()
@@ -34,97 +20,104 @@ describe("add command", () => {
     return { stdin, stdout }
   }
 
-  it("should add one task to JSON save file", async () => {
+  it.sequential("should add one task to JSON save file", async () => {
     const { stdin } = mockStdinAndStdout()
     async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
       const saveFileData = readSaveFileContent()
       const taskEntries = JSON.parse(saveFileData)
-      await expect(taskEntries.length).toBe(
-        1,
-        "Save file should have one new task"
-      )
-      await expect(saveFileData).toMatch(
+      expect(taskEntries.length).toBe(1, "Save file should have one new task")
+      expect(saveFileData).toMatch(
         /"createdAt":/,
         "Save file should have one new task with createdAt field"
       )
-      await expect(saveFileData).toMatch(
+      expect(saveFileData).toMatch(
         /"updatedAt":null/,
         "Save file should have one new task with updatedAt field of null"
       )
-      await expect(saveFileData).toMatch(
+      expect(saveFileData).toMatch(
         /"id":"1","description":"Buy groceries"/,
         "Save file should have description of task"
       )
     }
-    main(onExit)
+    const callback = async () => await onExit()
+    main(callback)
     stdin.send('add "Buy groceries"')
     stdin.end()
+    await vi.waitFor(callback)
   })
 
-  it("should allow multiple tasks to be added", async () => {
+  it.sequential("should allow multiple tasks to be added", async () => {
     const { stdin } = mockStdinAndStdout()
     async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
       const saveFileData = readSaveFileContent()
       const taskEntries = JSON.parse(saveFileData)
-      await expect(taskEntries.length).toBe(
+      expect(taskEntries.length).toBe(
         3,
         "Save file should have three new tasks"
       )
-      await expect(saveFileData).toMatch(
+      expect(saveFileData).toMatch(
         /"id":"1","description":"FIRST'_'TASK"/,
         "Save file should have description of first task"
       )
-      await expect(saveFileData).toMatch(
+      expect(saveFileData).toMatch(
         /"id":"2","description":"second    task"/,
         "Save file should have description of first task"
       )
-      await expect(saveFileData).toMatch(
+      expect(saveFileData).toMatch(
         /"id":"3","description":"third  =  task"/,
         "Save file should have description of first task"
       )
     }
-    main(onExit)
+    const callback = async () => await onExit()
+    main(callback)
     stdin.send(`add "FIRST'_'TASK"` + EOL)
     stdin.send('add "second    task"' + EOL)
     stdin.send(' add      "  third  =  task "   ' + EOL)
     stdin.end()
+    await vi.waitFor(callback)
   })
 
-  it("should display invalid command message to user when invalid command is given", async () => {
-    const { stdin, stdout } = mockStdinAndStdout()
-    async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
-      await expect(stdout.output).toMatch(
-        new RegExp(String.raw`Invalid Command \[${invalidCommand}\] given.`),
-        "Invalid Command message should be displayed to user"
-      )
-      await expect(stdout.output).toMatch(
-        /List of valid commands:/,
-        "Invalid Command message list of commands should be displayed to user"
-      )
+  it.sequential(
+    "should display invalid command message to user when invalid command is given",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        expect(stdout.output).toMatch(
+          new RegExp(String.raw`Invalid Command \[${invalidCommand}\] given.`),
+          "Invalid Command message should be displayed to user"
+        )
+        expect(stdout.output).toMatch(
+          /List of valid commands:/,
+          "Invalid Command message list of commands should be displayed to user"
+        )
+      }
+      const invalidCommand = 'add" "Buy groceries"'
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(invalidCommand)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
     }
-    const invalidCommand = 'add" "Buy groceries"'
-    main(onExit)
-    stdin.send(invalidCommand)
-    stdin.end()
-    stdout.stop()
-  })
+  )
 
-  it("should not allow add command with more than two double quote present", async () => {
-    const { stdin, stdout } = mockStdinAndStdout()
-    async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
-      await expect(stdout.output).toMatch(
-        new RegExp(String.raw`Invalid Command \[${invalidCommand}\] given.`),
-        "Invalid Command message should be displayed to user"
-      )
+  it.sequential(
+    "should not allow add command with more than two double quote present",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        expect(stdout.output).toMatch(
+          new RegExp(String.raw`Invalid Command \[${invalidCommand}\] given.`),
+          "Invalid Command message should be displayed to user"
+        )
+      }
+      const invalidCommand = 'add "Buy groceries" test"'
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(invalidCommand)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
     }
-    const invalidCommand = 'add "Buy groceries" test"'
-    main(onExit)
-    stdin.send(invalidCommand)
-    stdin.end()
-    stdout.stop()
-  })
+  )
 })

--- a/tests/listCommand.test.js
+++ b/tests/listCommand.test.js
@@ -1,13 +1,9 @@
-import { describe, it, beforeEach, afterEach, expect } from "vitest"
-const fs = require("node:fs")
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest"
 const { EOL } = require("node:os")
+import { deleteSaveFile, readSaveFileContent } from "./testUtil.js"
 const { main } = require("../index.js")
-const { SAVE_FILE_PATH } = require("../storage/file.js")
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-const WAIT_TIME_FOR_IO_IN_MS = 500
-
-describe("list command", () => {
+describe("list command", async () => {
   beforeEach(() => {
     deleteSaveFile()
   })
@@ -15,16 +11,6 @@ describe("list command", () => {
   afterEach(() => {
     deleteSaveFile()
   })
-
-  function deleteSaveFile() {
-    if (fs.existsSync(SAVE_FILE_PATH)) {
-      fs.unlinkSync(SAVE_FILE_PATH)
-    }
-  }
-
-  function readSaveFileContent() {
-    return fs.readFileSync(SAVE_FILE_PATH, "utf8")
-  }
 
   function mockStdinAndStdout() {
     const stdin = require("mock-stdin").stdin()
@@ -34,60 +20,69 @@ describe("list command", () => {
     return { stdin, stdout }
   }
 
-  it("should list zero tasks when zero tasks are present", async () => {
-    const { stdin, stdout } = mockStdinAndStdout()
-    async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
-      const saveFileData = readSaveFileContent()
-      expect(saveFileData).toBe("", "Should have no saved tasks")
-      await expect(stdout.output).not.toMatch(
-        /Invalid Command \[list\] given/,
-        "Should not have invalid command message"
-      )
-      await expect(stdout.output).toMatch(/No Tasks Available/)
+  it.sequential(
+    "should list zero tasks when zero tasks are present",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toBe("", "Should have no saved tasks")
+        expect(stdout.output).not.toMatch(
+          /Invalid Command \[list\] given/,
+          "Should not have invalid command message"
+        )
+        expect(stdout.output).toMatch(/No Tasks Available/)
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`list` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
     }
-    main(onExit)
-    stdin.send(`list` + EOL)
-    stdin.end()
-    stdout.stop()
-  })
+  )
 
-  it("should reject list command with invalid status keyword", async () => {
-    const invalidListCommand = `list special`
-    const { stdin, stdout } = mockStdinAndStdout()
-    async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
-      await expect(stdout.output).toMatch(
-        new RegExp(
-          String.raw`Invalid Command \[${invalidListCommand}\] given.`
-        ),
-        "Invalid Command message should be displayed to user"
-      )
+  it.sequential(
+    "should reject list command with invalid status keyword",
+    async () => {
+      const invalidListCommand = `list special`
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        expect(stdout.output).toMatch(
+          new RegExp(
+            String.raw`Invalid Command \[${invalidListCommand}\] given.`
+          ),
+          "Invalid Command message should be displayed to user"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(invalidListCommand + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
     }
-    main(onExit)
-    stdin.send(invalidListCommand + EOL)
-    stdin.end()
-    stdout.stop()
-  })
+  )
 
-  it("should list two tasks after adding two tasks", async () => {
+  it.sequential("should list two tasks after adding two tasks", async () => {
     const { stdin, stdout } = mockStdinAndStdout()
     async function onExit() {
-      await sleep(WAIT_TIME_FOR_IO_IN_MS)
-      await expect(stdout.output).toMatch(
+      expect(stdout.output).toMatch(
         /1\) first task \[todo\]/,
         "Should list first task"
       )
-      await expect(stdout.output).toMatch(
+      expect(stdout.output).toMatch(
         /2\) second task \[todo\]/,
         "Should list second task"
       )
     }
-    main(onExit)
+    const callback = async () => await onExit()
+    main(callback)
     stdin.send(`add "first task"` + EOL)
     stdin.send(`add "second task"` + EOL)
     stdin.send(`list ` + EOL)
     stdin.end()
     stdout.stop()
+    await vi.waitFor(callback)
   })
 })

--- a/tests/markDoneCommand.test.js
+++ b/tests/markDoneCommand.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+const { EOL } = require("node:os")
+import { deleteSaveFile, readSaveFileContent } from "./testUtil.js"
+import { main } from "../index.js"
+
+describe("mark done command", async () => {
+  beforeEach(() => {
+    deleteSaveFile()
+  })
+
+  afterEach(() => {
+    deleteSaveFile()
+  })
+
+  function mockStdinAndStdout() {
+    const stdin = require("mock-stdin").stdin()
+    const { stdout } = require("stdout-stderr")
+    stdout.print = true
+    stdout.start()
+    return { stdin, stdout }
+  }
+
+  it.sequential(
+    "should mark first todo task status to done status and change task updatedAt to not null",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"done\"/,
+          "Save data should have updated task status from todo to done"
+        )
+        expect(saveFileData).not.toMatch(
+          /\"updatedAt\":null/,
+          "Save data should have updated task updatedAt from null to some value"
+        )
+        expect(stdout.output).toMatch(
+          new RegExp(String.raw`Marked Task 1 as done`),
+          "Should display user message that task one is marked as done"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-done 1` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should not mark task as done with negative index",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"todo\"/,
+          "Save data should not have updated task status from todo to done"
+        )
+        expect(saveFileData).toMatch(
+          /\"updatedAt\":null/,
+          "Save data should not have updated task updatedAt from null"
+        )
+        expect(stdout.output).toMatch(
+          /Invalid index provided \[-1\]/,
+          "Invalid index message should be displayed to user"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-done -1` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should not mark task as done with index greater than task list size",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"todo\"/,
+          "Save data should not have updated task status from todo to done"
+        )
+        expect(saveFileData).toMatch(
+          /\"updatedAt\":null/,
+          "Save data should not have updated task updatedAt from null"
+        )
+        expect(stdout.output).toMatch(
+          /Invalid index provided \[2\]/,
+          "Invalid index message should be displayed to user"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-done 2` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should not show invalid command with multiple space between command and index",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"done\"/,
+          "Save data should have updated task status from todo to done"
+        )
+        expect(saveFileData).not.toMatch(
+          /\"updatedAt\":null/,
+          "Save data should have updated task updatedAt from null to some value"
+        )
+        expect(stdout.output).not.toMatch(
+          /Invalid Command/,
+          "Invalid Command message should not be displayed to user"
+        )
+        expect(stdout.output).toMatch(
+          /Marked Task 1 as done/,
+          "Should display user message that task one is marked as done"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-done    1  ` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+})

--- a/tests/markInProgressCommand.test.js
+++ b/tests/markInProgressCommand.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+const { EOL } = require("node:os")
+import { deleteSaveFile, readSaveFileContent } from "./testUtil.js"
+import { main } from "../index.js"
+
+describe("mark in progress command", async () => {
+  beforeEach(() => {
+    deleteSaveFile()
+  })
+
+  afterEach(() => {
+    deleteSaveFile()
+  })
+
+  function mockStdinAndStdout() {
+    const stdin = require("mock-stdin").stdin()
+    const { stdout } = require("stdout-stderr")
+    stdout.print = true
+    stdout.start()
+    return { stdin, stdout }
+  }
+
+  it.sequential(
+    "should mark first todo task status to in-progress status and change task updatedAt to not null",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"in-progress\"/,
+          "Save data should have updated task status from todo to in-progress"
+        )
+        expect(saveFileData).not.toMatch(
+          /\"updatedAt\":null/,
+          "Save data should have updated task updatedAt from null to some value"
+        )
+        expect(stdout.output).toMatch(
+          new RegExp(String.raw`Marked Task 1 as in-progress`),
+          "Should display user message that task one is marked as in-progress"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-in-progress 1` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should not mark task as in-progress with negative index",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"todo\"/,
+          "Save data should have not updated task status from todo"
+        )
+        expect(saveFileData).toMatch(
+          /\"updatedAt\":null/,
+          "Save data should not have updated task updatedAt from null"
+        )
+        expect(stdout.output).not.toMatch(
+          new RegExp(String.raw`Marked Task 1 as in-progress`),
+          "Should not display user message that task one is marked as in-progress"
+        )
+        expect(stdout.output).toMatch(
+          /Invalid index provided \[-1\]/,
+          "Invalid index message should be displayed to user"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-in-progress -1` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should not mark task as in-progress with index greater than task list",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"status\":\"todo\"/,
+          "Save data should have not updated task status from todo"
+        )
+        expect(saveFileData).toMatch(
+          /\"updatedAt\":null/,
+          "Save data should not have updated task updatedAt from null"
+        )
+        expect(stdout.output).toMatch(
+          /Invalid index provided \[2\]/,
+          "Invalid index message should be displayed to user"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "first task"` + EOL)
+      stdin.send(`mark-in-progress 2` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+})

--- a/tests/testUtil.js
+++ b/tests/testUtil.js
@@ -1,0 +1,17 @@
+const fs = require("node:fs")
+const { SAVE_FILE_PATH } = require("../storage/file")
+
+function deleteSaveFile() {
+  if (fs.existsSync(SAVE_FILE_PATH)) {
+    fs.unlinkSync(SAVE_FILE_PATH)
+  }
+}
+
+function readSaveFileContent() {
+  return fs.readFileSync(SAVE_FILE_PATH, "utf8")
+}
+
+module.exports = {
+  deleteSaveFile,
+  readSaveFileContent,
+}


### PR DESCRIPTION
Fix flaky tests due to parallel execution (make tests synchronous and disable parallelism runs of multiple test files at the same time with `"test": "vitest --sequence.concurrent=false --no-file-parallelism"`)
- https://vitest.dev/guide/improving-performance#test-isolation

Add command for `mark-done`
Add command for `mark-in-progress`