### PR TITLE
Add delete command and tests

### DIFF
--- a/commands/commandFactory.js
+++ b/commands/commandFactory.js
@@ -1,6 +1,7 @@
 const { Task } = require("../model/task")
 const { getAllTasks } = require("../storage/file")
 const { AddCommand } = require("./addCommand")
+const { DeleteCommand } = require("./deleteCommand")
 const { InvalidCommand } = require("./invalidCommand")
 const { ListCommand } = require("./listCommand")
 const { MarkDoneCommand } = require("./markDoneCommand")
@@ -22,6 +23,8 @@ class CommandFactory {
         return createMarkInProgressCommand(line)
       case "update":
         return createUpdateCommand(line)
+      case "delete":
+        return createDeleteCommand(line)
       default:
         return new InvalidCommand(line)
     }
@@ -73,6 +76,14 @@ function createUpdateCommand(line) {
   return isValid
     ? new UpdateCommand(getAllTasks(), index, description)
     : new InvalidCommand(line)
+}
+
+function createDeleteCommand(line) {
+  const { isValid, index } = DeleteCommand.parseInput(line.slice(6).trim())
+  if (!isValid) {
+    return new InvalidCommand(line)
+  }
+  return new DeleteCommand(getAllTasks(), index)
 }
 
 module.exports = { CommandFactory }

--- a/commands/deleteCommand.js
+++ b/commands/deleteCommand.js
@@ -1,0 +1,39 @@
+const { writeToSaveFile } = require("../storage/file")
+
+class DeleteCommand {
+  constructor(tasks, index) {
+    // index is zero based
+    this.tasks = tasks
+    this.index = index - 1
+  }
+
+  static parseInput(input) {
+    const found = input.trim().match(new RegExp(String.raw`^(?<index>-?\d+)$`))
+    if (found == null || found.groups == null || found.groups.index == null) {
+      return { isValid: false }
+    }
+    try {
+      const index = Number.parseInt(found.groups.index)
+      return {
+        index,
+        isValid: true,
+      }
+    } catch (error) {
+      return { isValid: false }
+    }
+  }
+
+  execute() {
+    if (this.index < 0 || this.tasks[this.index] == null) {
+      return `Invalid index provided [${this.index + 1}]`
+    }
+    // update task ids strings (prevent issue with adding new tasks due to id conflict)
+    const remainingTasks = this.tasks
+      .filter((_, index) => index !== this.index)
+      .map((task, index) => ({ ...task, id: `${index + 1}` }))
+    writeToSaveFile(JSON.stringify(remainingTasks))
+    return `Deleted Task ${this.index + 1}`
+  }
+}
+
+module.exports = { DeleteCommand }

--- a/tests/deleteCommand.test.js
+++ b/tests/deleteCommand.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+const { EOL } = require("node:os")
+import { deleteSaveFile, readSaveFileContent } from "./testUtil.js"
+import { main } from "../index.js"
+
+describe("delete command", async () => {
+  beforeEach(() => {
+    deleteSaveFile()
+  })
+
+  afterEach(() => {
+    deleteSaveFile()
+  })
+
+  function mockStdinAndStdout() {
+    const stdin = require("mock-stdin").stdin()
+    const { stdout } = require("stdout-stderr")
+    stdout.print = true
+    stdout.start()
+    return { stdin, stdout }
+  }
+
+  it.sequential("should delete task", async () => {
+    const { stdin, stdout } = mockStdinAndStdout()
+    async function onExit() {
+      const saveFileData = readSaveFileContent()
+      expect(saveFileData).not.toMatch(
+        /\"id\":\"1\"/,
+        "Save data should have deleted task id"
+      )
+      expect(saveFileData).not.toMatch(
+        /\"description\":\"delete task description\"/,
+        "Save data should have delete task description"
+      )
+      expect(stdout.output).toMatch(
+        new RegExp(String.raw`Deleted Task 1`),
+        "Should display user message that task is deleted"
+      )
+    }
+    const callback = async () => await onExit()
+    main(callback)
+    stdin.send(`add "delete task description"` + EOL)
+    stdin.send(`delete 1` + EOL)
+    stdin.end()
+    stdout.stop()
+    await vi.waitFor(callback)
+  })
+
+  it.sequential(
+    "should not delete task for invalid negative index",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"id\":\"1\"/,
+          "Save data should not have deleted task id"
+        )
+        expect(saveFileData).toMatch(
+          /\"description\":\"not deleted task description\"/,
+          "Save data should not delete task description"
+        )
+        expect(stdout.output).not.toMatch(
+          new RegExp(String.raw`Deleted Task 1`),
+          "Should not display user message that task is deleted"
+        )
+        expect(stdout.output).toMatch(
+          /Invalid index provided \[\-1\]/,
+          "Should display user message that invalid negative delete index is provided"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "not deleted task description"` + EOL)
+      stdin.send(`delete -1` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should not delete task for invalid index that exceed task list length",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        expect(saveFileData).toMatch(
+          /\"id\":\"1\"/,
+          "Save data should not have deleted task id"
+        )
+        expect(saveFileData).toMatch(
+          /\"description\":\"not deleted task description\"/,
+          "Save data should not delete task description"
+        )
+        expect(stdout.output).not.toMatch(
+          new RegExp(String.raw`Deleted Task 1`),
+          "Should not display user message that task is deleted"
+        )
+        expect(stdout.output).toMatch(
+          /Invalid index provided \[2\]/,
+          "Should display user message that delete index is invalid"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "not deleted task description"` + EOL)
+      stdin.send(`delete 2` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+
+  it.sequential(
+    "should add new task after deletion without overriding existing tasks",
+    async () => {
+      const { stdin, stdout } = mockStdinAndStdout()
+      async function onExit() {
+        const saveFileData = readSaveFileContent()
+        const taskEntries = JSON.parse(saveFileData)
+        expect(saveFileData).toMatch(
+          /\"id\":\"1\",\"description\":\"not deleted task description\"/,
+          "Save data should not have deleted task id one"
+        )
+        expect(saveFileData).toMatch(
+          /\"id\":\"2\",\"description\":\"not deleted second task description\"/,
+          "Save data should not have deleted task id two"
+        )
+        expect(saveFileData).toMatch(
+          /\"id\":\"3\",\"description\":\"not deleted fourth task description\"/,
+          "Save data should not have deleted task id four"
+        )
+        expect(saveFileData).toMatch(
+          /\"id\":\"4\",\"description\":\"new task description\"/,
+          "Save data should have added new task after deletion"
+        )
+        expect(saveFileData).not.toMatch(
+          /\"id\":\"5\"/,
+          "Save data should not have id = 5"
+        )
+        expect(taskEntries.length).toBe(
+          4,
+          "Save data should not have five tasks"
+        )
+        expect(stdout.output).toMatch(
+          new RegExp(String.raw`Deleted Task 3`),
+          "Should display user message that task is deleted"
+        )
+      }
+      const callback = async () => await onExit()
+      main(callback)
+      stdin.send(`add "not deleted task description"` + EOL)
+      stdin.send(`add "not deleted second task description"` + EOL)
+      stdin.send(`add "deleted third task description"` + EOL)
+      stdin.send(`add "not deleted fourth task description"` + EOL)
+      stdin.send(`delete 3` + EOL)
+      stdin.send(`add "new task description"` + EOL)
+      stdin.end()
+      stdout.stop()
+      await vi.waitFor(callback)
+    }
+  )
+})


### PR DESCRIPTION
Add delete command to delete by task id

Regenerate new ids after delete of task, to ensure that new tasks added will not have overriding ids
e.g. 
```
1) first
2) second
3) third

delete 2
add new task "fourth"

1) first
2) third
3) fourth
```